### PR TITLE
Add LICENSE.txt and basic setup instructions

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,27 @@
+Copyright (c) 2016, DARIAH-DE
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of sonar-shib-plugin nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -4,3 +4,30 @@ Sonar Shibboleth plugin
 Simple Shibboleth plugin for [Sonar](http://www.sonarsource.org/), implemented from the limited needs of Stockholm University.
 
 The implementation is based on the [Sonar OpenID Plugin](http://docs.codehaus.org/display/SONAR/OpenID+Plugin).
+
+## Installation
+
+1. Compile the plugin with maven
+2. Put it into the _SONARQUBE_HOME/extensions/plugins_ directory
+3. Restart the SonarQube server
+
+## Usage
+
+The following properties must be added to _SONARQUBE_HOME/conf/sonar.properties_:
+
+```
+#------------------------
+# Sonar Shibboleth Plugin
+#------------------------
+
+# Automatically create users
+# Default is false.
+sonar.authenticator.createUsers: true
+
+# set security realm to use shibboleth
+sonar.security.realm=shibboleth
+
+# session initialisation url
+sonar.shibboleth.sessionInitializer=/shibboleth/validate
+```
+

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The implementation is based on the [Sonar OpenID Plugin](http://docs.codehaus.or
 2. Put it into the _SONARQUBE_HOME/extensions/plugins_ directory
 3. Restart the SonarQube server
 
-## Usage
+## Setup
 
 The following properties must be added to _SONARQUBE_HOME/conf/sonar.properties_:
 
@@ -27,7 +27,12 @@ sonar.authenticator.createUsers: true
 # set security realm to use shibboleth
 sonar.security.realm=shibboleth
 
-# session initialisation url
+# session initialisation url (realtive to sonar root)
 sonar.shibboleth.sessionInitializer=/shibboleth/validate
+
+# local users - authenticated internally not through Shibboleth
+sonar.security.localUsers=foo,bar
 ```
+
+Finally, enforce Shibboleth authentication on the `sonar.shibboleth.sessionInitializer` URL.
 


### PR DESCRIPTION
Added a LICENSE.txt file as per [GitHub recommendation](https://help.github.com/articles/open-source-licensing/)

The pom.xml already states the license, but this makes it explicit.
